### PR TITLE
Initialize session on startup for reliable link auto-open

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The extension maintains a WebSocket connection to Pushbullet's servers to receiv
 
 ### Auto-open Links
 
-When enabled (default), links sent directly to your Chrome device will automatically open in a new tab. You can disable this feature in the extension's settings.
+When enabled (default), links sent directly to your Chrome device will automatically open in a new tab. The background service now initializes on browser start for more reliable auto-opening. You can disable this feature in the extension's settings.
 
 ## Privacy
 

--- a/background.js
+++ b/background.js
@@ -28,13 +28,18 @@ let sessionCache = {
 // Initialize extension
 chrome.runtime.onInstalled.addListener(() => {
   console.log('Pushbullet extension installed');
-  
+
   // Set up context menu
   setupContextMenu();
-  
-  // Initialize session cache
+});
+
+// Initialize session cache when Chrome starts
+chrome.runtime.onStartup.addListener(() => {
   initializeSessionCache();
 });
+
+// Ensure session cache is initialized when the service worker is loaded
+initializeSessionCache();
 
 // Initialize session cache
 async function initializeSessionCache() {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Pushbullet for Chrome (Unofficial)",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Unofficial Manifest V3 compatible Pushbullet client - not affiliated with Pushbullet Inc.",
     "manifest_version": 3,
     "icons": {


### PR DESCRIPTION
## Summary
- initialize Pushbullet session when the service worker starts so link pushes can open automatically
- document auto-open link behavior and bump extension version

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689928c95260832daf9bb01ecc47edb3